### PR TITLE
Better patch for #37 (missing sidebar on direct comic pages)

### DIFF
--- a/assets/js/modules/dom-modifier.js
+++ b/assets/js/modules/dom-modifier.js
@@ -120,6 +120,10 @@ export default class DomModifier {
 
 		$('#news, #newspost').replaceWith('<qc-news></qc-news>');
 
+		if (comicDirective.parent().siblings('.small-2').length === 0) {
+			// There's no column after the comic: Insert our own
+			comicDirective.parent().after('<div class="small-2 medium-expand column"></div>');
+		}
 		comicDirective.parent().siblings('.small-2').prepend('<qc-extra></qc-extra>');
 
 		// Set a base (required by Angular's html5Mode)

--- a/assets/templates/changeLog.html
+++ b/assets/templates/changeLog.html
@@ -36,7 +36,10 @@
 					<li></li>
 				</ul>
 				-->
-				
+				<h4>0.6.1 <small>December 8, 2019</small></h4>
+		    		<ul>
+					<li>Fix missing sidebar when loading a comic directly by number in URL.</li>
+				</ul>
 				<h4>0.6.0 <small>March 7, 2019</small></h4>
 				<div class="change-log-entry">
 					<p class="developer-message">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "questionable-content-spa",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "questionable-content-spa",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Questionable Content Single-Page Application with Extra Features",
 	"main": "app.js",
 	"scripts": {


### PR DESCRIPTION
This patch is more idiomatic than #38, placing the change in the proper file and location (with comment), and using jQuery rather than raw JavaScript. It tests the DOM to see if the required column element (class ".small-2") is present and creates it if not, rather than testing the URL. 

It also includes a version update in both the package and package-lock files, as well as an entry in the change-log, making for a more complete fix. 

I realize you're busy, so I wanted to make things as simple as possible for you to help the fix get out quickly. Cheers!