### PR TITLE
Fix for dord and privacy links

### DIFF
--- a/assets/js/modules/dom-modifier.js
+++ b/assets/js/modules/dom-modifier.js
@@ -124,6 +124,18 @@ export default class DomModifier {
 			// There's no column after the comic: Insert our own
 			comicDirective.parent().after('<div class="small-2 medium-expand column"></div>');
 		}
+		if ($('a[href*="dord.png"]').siblings('div.small-2').length !== 0) {
+			// There's a dord Link is in the way: Move it to the bottom of the page
+			let donationLink = $('[href*="https://www.paypal.com/"]');
+			donationLink.after($('[href*="dord.png"]'));
+			donationLink.after('•');
+		}
+		if ($('a[href*="privacy.php"]').siblings('div.small-2').length !== 0) {
+			// There's a privacy link in the way: Move it to the bottom of the page
+			let donationLink = $('[href*="https://www.paypal.com/"]');
+			donationLink.after($('[href*="privacy.php"]'));
+			donationLink.after('•');
+		}
 		comicDirective.parent().siblings('.small-2').prepend('<qc-extra></qc-extra>');
 
 		// Set a base (required by Angular's html5Mode)

--- a/assets/templates/changeLog.html
+++ b/assets/templates/changeLog.html
@@ -36,6 +36,10 @@
 					<li></li>
 				</ul>
 				-->
+		    		<h4>0.6.2 <small>December 8, 2019</small></h4>
+		    		<ul>
+					<li>Moved dord and Privacy Policy links to bottom of the page for all pages.</li>
+				</ul>
 				<h4>0.6.1 <small>December 8, 2019</small></h4>
 		    		<ul>
 					<li>Fix missing sidebar when loading a comic directly by number in URL.</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "questionable-content-spa",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "questionable-content-spa",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"description": "Questionable Content Single-Page Application with Extra Features",
 	"main": "app.js",
 	"scripts": {


### PR DESCRIPTION
Per  discussion on #39. If the links are in the way, they are moved to the bottom of the page, just like they are on the front page of the site. I went ahead and tested each link separately, as it wasn't any slower (both 6-8ms), and it's more robust. 